### PR TITLE
Update to tripal 2.1b3 + other fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,28 +1,30 @@
-# This is a sample configuration to run a Drupal-instance with Docker-Compose.
-# For customization options see: https://docs.docker.com/compose/yml/
+# This is a sample configuration to run a Tripal instance with Docker-Compose.
 
-web:
-  #build: .
-  image: erasche/tripal:latest
-  links:
-    - db:postgres
-  volumes:
-    - /var/www/html/sites
-    - /var/www/private
-  environment:
-    UPLOAD_LIMIT: 20M
-    MEMORY_LIMIT: 128M
-    BASE_URL: "http://localhost:3000/tripal"
-    BASE_URL_PROTO: "http://"
-  ports:
-    - "3000:80"
+version: '2'
+services:
 
-db:
-  image: erasche/chado:latest
-  environment:
-    - POSTGRES_PASSWORD=password
-      # The default chado image would try to install the schema on first run,
-      # we just want the tools to be available.
-    - INSTALL_CHADO_SCHEMA=0
-  volumes:
-    - /var/lib/postgresql/9.4/
+    web:
+      #build: .
+      image: erasche/tripal:latest
+      links:
+        - db:postgres
+      volumes:
+        - /var/www/html/sites
+        - /var/www/private
+      environment:
+        UPLOAD_LIMIT: 20M
+        MEMORY_LIMIT: 128M
+        BASE_URL: "http://localhost:3000/tripal"
+        BASE_URL_PROTO: "http://"
+      ports:
+        - "3000:80"
+
+    db:
+      image: erasche/chado:latest
+      environment:
+        - POSTGRES_PASSWORD=postgres
+          # The default chado image would try to install the schema on first run,
+          # we just want the tools to be available.
+        - INSTALL_CHADO_SCHEMA=0
+      volumes:
+        - /var/lib/postgresql/9.4/

--- a/tripal_chado_install
+++ b/tripal_chado_install
@@ -4,9 +4,7 @@ psql -U $DB_USER -h $DB_HOST -p $DB_PORT $DB_NAME < /chado-master-tripal.sql
 echo "alter database postgres set search_path = '$user',public,chado;" | psql -U $DB_USER -h $DB_HOST -p $DB_PORT $DB_NAME;
 echo "CREATE INDEX bingroup_boxrange ON featuregroup USING gist (chado.boxrange(fmin, fmax)) WHERE (is_root = 1);" | psql -U $DB_USER -h $DB_HOST -p $DB_PORT $DB_NAME;
 
-
-
-drush pm-download ctools views tripal
+drush pm-download ctools views tripal-7.x-2.1-beta3
 drush pm-enable ctools views views_ui
 
 wget --no-check-certificate https://drupal.org/files/drupal.pgsql-bytea.27.patch && patch -p1 < drupal.pgsql-bytea.27.patch
@@ -15,6 +13,9 @@ cd /var/www/html/sites/all/modules/views
 patch -p1 < ../tripal/tripal_views/views-sql-compliant-three-tier-naming-1971160-22.patch
 
 drush pm-enable tripal_core
+if [ ! -z "$TRIPAL_DOWNLOAD_MODULES" ]; then
+    drush pm-download ${TRIPAL_DOWNLOAD_MODULES}
+fi
 drush pm-enable tripal_views tripal_db tripal_cv tripal_organism tripal_analysis tripal_feature ${TRIPAL_ADDITIONAL_MODULES}
 chgrp -R www-data /var/www/html/sites/default/files
 chmod -R g+rw /var/www/html/sites/default/files


### PR DESCRIPTION
- Tripal 2.1b3 seems to be more maintained and near final releas, so use it
- Switched to docker compose v2 to be consistent with https://github.com/galaxy-genome-annotation/dockerized-gmod-deployment
- Updated the db password too
- Added a new TRIPAL_DOWNLOAD_MODULES because sometimes you want to install a specific version of a module, for example for blast module we need the dev version (as stable is... broken):
  `drush pm-download tripal_analysis_blast-7.x-2.x-dev && drush pm-enable tripal_analysis_blast`
