### PR TITLE
Get rid of BASE_URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,6 @@ ADD sites/ sites/
 ADD entrypoint.sh README.md  /
 ADD /scripts/ /scripts/
 
-ADD tripal_chado_install /scripts/setup.d/50tripal_chado_install
 ADD tripal_apache.conf /etc/apache2/conf-enabled/tripal_apache.conf
 
 ENV TRIPAL_GIT_CLONE_MODULES=""

--- a/README.md
+++ b/README.md
@@ -23,11 +23,9 @@ services:
     environment:
       UPLOAD_LIMIT: 20M
       MEMORY_LIMIT: 128M
-      VIRTUAL_HOST: foo.bar.edu
-      # If you run the image on a different port, then BASE_URL must be set
-      # correctly. If you run on :80 it should be OK to remove BASE_URL
-      BASE_URL: "http://foo.bar.edu:3000"
-      BASE_URL_PROTO: "http://"
+      TRIPAL_DOWNLOAD_MODULES: "tripal_analysis_blast-7.x-2.x-dev"
+      TRIPAL_GIT_CLONE_MODULES: "https://github.com/tripal/tripal_analysis_expression.git"
+      TRIPAL_ADDITIONAL_MODULES: "tripal_analysis_blast tripal_analysis_expression tripal_analysis_intepro"
     ports:
       - "3000:80"
   db:
@@ -43,7 +41,16 @@ services:
 
 ## Configuring the Container
 
-You will need to set a `BASE_URL` unfortunately, if drupal/tripal use this in finding the location of the CSS and other static files. The container will come up correctly and you will be able to access the page, but it will not be styled without this set correctly.
+By default, tripal should display properly by going to http://foo.bar.edu:3000/tripal.
+If the page is not styled correctly, we exposed some environment variables that you can customize:
+
+```
+# In most situations, the following variables don't need to be set
+# as they are autodetected. If needed, setting these variables will disable autodetection
+VIRTUAL_HOST: foo.bar.edu # Guessed from HTTP_X_FORWARDED_HOST if behind a proxy, or from hostname
+BASE_URL_PROTO: "http" # Guessed from apache REQUEST_SCHEME variable
+BASE_URL: "http://foo.bar.edu:3000/tripal" # Guessed from VIRTUAL_HOST and BASE_URL_PROTO
+```
 
 ### Customizing the Image
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,6 @@ services:
       environment:
         UPLOAD_LIMIT: 20M
         MEMORY_LIMIT: 128M
-        BASE_URL: "http://localhost:3000/tripal"
-        BASE_URL_PROTO: "http://"
       ports:
         - "3000:80"
 

--- a/scripts/pre-launch.d/05servername_baseurl
+++ b/scripts/pre-launch.d/05servername_baseurl
@@ -1,18 +1,8 @@
-: "${BASE_URL_PROTO:='https://'}"
-
 if [ -n "$VIRTUAL_HOST" ]; then
 	if [ -z "$SERVERNAME" ]; then
 		SERVERNAME=$(echo "$VIRTUAL_HOST" | cut -f 1 -d ,)
-	fi
-	if [ -z "$BASE_URL" ]; then
-		BASE_URL="${BASE_URL_PROTO}"$(echo "$VIRTUAL_HOST" | cut -f 1 -d ,)
 	fi
 fi
 
 : "${SERVERNAME:=$(cat /etc/hostname)}"
 echo ServerName "${SERVERNAME}" >> /etc/apache2/apache2.conf
-
-if [ -n "$BASE_URL" ]; then
-	export BASE_URL
-	echo -e "# Drupal's base_url-variable\nexport BASE_URL=${BASE_URL}" >> /etc/bash.bashrc
-fi

--- a/scripts/setup.d/50tripal_chado_install
+++ b/scripts/setup.d/50tripal_chado_install
@@ -5,7 +5,7 @@ echo "alter database postgres set search_path = '$user',public,chado;" | psql -U
 echo "CREATE INDEX bingroup_boxrange ON featuregroup USING gist (chado.boxrange(fmin, fmax)) WHERE (is_root = 1);" | psql -U $DB_USER -h $DB_HOST -p $DB_PORT $DB_NAME;
 
 drush pm-download ctools views tripal #-7.x-2.1-beta3 # tripal 2.1 will require chado 1.31
-drush pm-enable ctools views views_ui
+drush pm-enable ctools views views_ui libraries services
 
 wget --no-check-certificate https://drupal.org/files/drupal.pgsql-bytea.27.patch && patch -p1 < drupal.pgsql-bytea.27.patch
 

--- a/sites/default/settings.php
+++ b/sites/default/settings.php
@@ -14,7 +14,30 @@ $databases['default']['default'] = array(
 );
 
 if (getenv('BASE_URL'))
-  $base_url = getenv('BASE_URL');
+    // Use BASE_URL if defined by user
+    $base_url = getenv('BASE_URL');
+else {
+    // Guess protocol
+    if (getenv('BASE_URL_PROTO'))
+        $protocol = getenv('BASE_URL_PROTO');
+    else if (array_key_exists("REQUEST_SCHEME", $_SERVER))
+        $protocol = $_SERVER['REQUEST_SCHEME'];
+    else
+        $protocol = 'https';
+
+    // Guess host
+    if (getenv('VIRTUAL_HOST'))
+        // Use VIRTUAL_HOST if defined by user
+        $host = getenv('VIRTUAL_HOST');
+    else if (array_key_exists("HTTP_X_FORWARDED_HOST", $_SERVER))
+        // Else trust the proxy
+        $host = explode(', ', $_SERVER['HTTP_X_FORWARDED_HOST'])[0];
+    else
+        $host = NULL; // Unable to guess host part, let drupal decide what to do
+
+    if ($host)
+        $base_url = $protocol . "://" . $host . '/tripal';
+}
 
 $update_free_access = FALSE;
 


### PR DESCRIPTION
Good news! With this we no longer need to define a BASE_URL env variable for tripal (at least in most cases I think)
