### PR TITLE
Changing the DB_NAME to 'postgres' fixes issue #19

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         MEMORY_LIMIT: 128M
         BASE_URL: "http://localhost:3000/tripal"
         BASE_URL_PROTO: "http://"
-        DB_NAME: 'tripal'
+        DB_NAME: 'postgres'
       ports:
         - "3000:80"
 


### PR DESCRIPTION
I'm not sure if this would have any side effects but it successfully allowed by to bypass the error in issue #19 and get all 3 containers up and running.