### PR TITLE
V3.x - added .gitattributes to conserve LF line endings in cloned files (for Docker compliance)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,5 +12,5 @@ scripts/pre-launch.d/* text eol=lf
 scripts/setup.d/* text eol=lf
 *.diff text eol=lf
 *.sql text eol=lf
-*.conf
-*.inc
+*.conf text eol=lf
+*.inc text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Declare files that will always have LF line endings on checkout.
+*.sh text eol=lf
+*.ini text eol=lf
+*.php text eol=lf
+logrotate.d/* text eol=lf
+scripts/pre-launch.d/* text eol=lf
+scripts/setup.d/* text eol=lf
+*.diff text eol=lf
+*.sql text eol=lf
+*.conf
+*.inc

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
+#
+# Specifying gitattrubutes since Docker generally needs LF not CRLF in its files
+# but Windows IDE's may overwrite these with CRLF during checkout, then creating
+# some peculiar practical Linux runtime errors in the Docker containers.
+#
 # Declare files that will always have LF line endings on checkout.
 *.sh text eol=lf
 *.ini text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 #
-# Specifying gitattrubutes since Docker generally needs LF not CRLF in its files
+# Specifying gitattributes since Docker generally needs LF not CRLF in its files
 # but Windows IDE's may overwrite these with CRLF during checkout, then creating
 # some peculiar practical Linux runtime errors in the Docker containers.
 #


### PR DESCRIPTION
I sometimes work on an IDE under Microsoft Windows, sometimes on Mac; noticed git remappings of line endings to CRLF on Windows broke some of the docker container components (like shell scripts) so I thought that perhaps a .gitattributes files might help